### PR TITLE
fix(image): cleanup entrypoint script

### DIFF
--- a/start.nginx.sh
+++ b/start.nginx.sh
@@ -16,7 +16,6 @@ cp /tmp/nginx.conf /etc/nginx/nginx.conf
 
 # Refresh the environment
 php artisan storage:link
-php artisan horizon:publish
 php artisan route:cache
 php artisan view:cache
 php artisan config:cache
@@ -25,6 +24,5 @@ php artisan migrate --force
 php artisan instance:actor
 
 # Finally run everything
-php artisan websockets:serve --host=127.0.0.1 &
 php-fpm -D &
 nginx -g 'daemon off;'


### PR DESCRIPTION
Running this docker image, I found two benign log statements generated by the entrypoint script that seem like they can be cleaned up 

```
WARN  Horizon no longer publishes its assets. You may stop calling the `horizon:publish` command.
``` 

```
ERROR  There are no commands defined in the "websockets" namespace.
```

To address these, i suggest:
- removing the `horizon:publish` command as recommended by the logfile
- remove the `websockets:server` command. it shouldn't be necessary based on setting the socket path in the `www.conf` file which is done by the dockerfile.

Running the resultant image results in nginx still connecting to the php application