### PR TITLE
feat(image): run as ww-data user by default

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -112,8 +112,13 @@ RUN cp -r storage storage.skel \
   && mkdir -p /run/php-fpm \
   && chown www-data:www-data /run/php-fpm \
   && sed -i 's/listen = 127.0.0.1:9000/listen = \/run\/php-fpm\/php-fpm.sock/' /usr/local/etc/php-fpm.d/www.conf \
+  # since we're specifing running as the www-data user below, we can remove the following lines from our php-fpm config to avoid a benign warning
+  && sed -i '/user = www-data/d' /usr/local/etc/php-fpm.d/www.conf \
+  && sed -i '/group = www-data/d' /usr/local/etc/php-fpm.d/www.conf \
   && rm -f /usr/local/etc/php-fpm.d/zz-docker.conf \
   && php artisan storage:link
 VOLUME /var/www/storage /var/www/bootstrap
+
+USER www-data
 
 CMD ["/var/www/contrib/docker/start.nginx.sh"]


### PR DESCRIPTION
Another issue i encountered while running this image, is that nginx will get socket access denied errors when trying to access the created socket that php fpm is listening on. While the parent directory is correctly owned by `www-data:www-data`, the created socket is owned by `root:root`.

If we try to address this socket issue with setting the below in the `www.conf` file:
```conf
listen.owner = www-data
listen.group = www-data
```
 that only partially addresses the issue, since nginx  tries to access the socket as the user `nobody`. We can then try to address the nginx issue with setting the `user www-data;` directive in the nginx config, but then we _still_ hit an error with accessing the default laravel log file.

This can all be solved by just running the container as `www-data` (id 33). While users can specify what user the image should run as, it seems like better practice to set this explicitly in the dockerfile for security and ease of use.

Functionally, **this is a breaking change if** users are specifying `APP_PORT` as < 1024, but they can easily re-map the port to the desired one when exposing the port in docker/kubernetes

@jessebot FYI