### PR TITLE
fix(image): start laravel horizon to process job queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ Available tags:
 - dev-nginx
 - v0.12.4-nginx
 
+## Environment Variables
+
+In addition to [the environment variables supported by PixelFed](https://docs.pixelfed.org/running-pixelfed/configuration.html), the following variables are supported:
+
+| Variable | Description | Default |
+| -------- | ----------- | ------- |
+| APP_PORT | Port that nginx will listen on | - |
+| APP_DOMAIN | Server name/domain for nginx configuration | - |
+| ENABLE_HORIZON | Enable Laravel Horizon queue worker in the container. By default, it is expected to be run elsewhere. | false |
+
 ## Maintainer
 
 Matt Kulka <matt@lqx.net>

--- a/start.nginx.sh
+++ b/start.nginx.sh
@@ -25,4 +25,7 @@ php artisan instance:actor
 
 # Finally run everything
 php-fpm -D &
+if [ "${ENABLE_HORIZON:-false}" = "true" ]; then
+    php artisan horizon &
+fi
 nginx -g 'daemon off;'


### PR DESCRIPTION
Pixelfed requires a worker to process the job queue. Documentation outlines methods to run either Laravel Horizon or Queue workers in the background: https://docs.pixelfed.org/running-pixelfed/installation.html#job-queueing

Currently the image does not run Horizon. By default, the Horizon dashboard looks like this:

![image](https://github.com/user-attachments/assets/38d6b1b8-e9df-4544-ac64-c0f5f4f6735f)

I first noticed this was an issue when trying to delete a post, the media would delete but not the post itself. Starting Horizon manually and re-deleting the post resolved the issue.

I tested this update to the Dockerfile, and we can see Horizon starts now:

![image](https://github.com/user-attachments/assets/6aba3c57-6894-43f2-b189-4989b085c75b)
